### PR TITLE
更新NuGett套件版本及測試斷言風格

### DIFF
--- a/Involver/Involver.csproj
+++ b/Involver/Involver.csproj
@@ -113,27 +113,30 @@
     <Compile Remove="Data\Migrations\20201122080616_unknown.Designer.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.38.0" />
-    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
-    <PackageReference Include="Azure.Identity" Version="1.11.4" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.60" />
-    <PackageReference Include="HtmlSanitizer" Version="8.0.843" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="Azure.Core" Version="1.47.1" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
+    <PackageReference Include="Azure.Identity" Version="1.14.2" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
+    <PackageReference Include="HtmlSanitizer" Version="9.0.886" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-    <PackageReference Include="SendGrid" Version="9.29.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
+    <PackageReference Include="SendGrid" Version="9.29.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.18">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/Involver/Pages/Shared/_Layout.cshtml
+++ b/Involver/Pages/Shared/_Layout.cshtml
@@ -6,14 +6,14 @@
         @if (!userManager.GetUserAsync(User).Result.Prime)
         {
             //Google AdSense
-            < script async src = "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3010246710169742"
-                crossorigin = "anonymous" ></ script >
+            <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3010246710169742"
+            crossorigin="anonymous"></script>
         }
     }
     else
     {
-        < script async src = "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3010246710169742"
-            crossorigin = "anonymous" ></ script >
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3010246710169742"
+            crossorigin="anonymous"></script>
     }
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/Involver/Pages/Shared/_Layout.cshtml
+++ b/Involver/Pages/Shared/_Layout.cshtml
@@ -6,18 +6,14 @@
         @if (!userManager.GetUserAsync(User).Result.Prime)
         {
             //Google AdSense
-            #if !DEBUG
-                < script async src = "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3010246710169742"
-                    crossorigin = "anonymous" ></ script >
-            #endif
+            < script async src = "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3010246710169742"
+                crossorigin = "anonymous" ></ script >
         }
     }
     else
     {
-        #if !DEBUG
-            < script async src = "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3010246710169742"
-                crossorigin = "anonymous" ></ script >
-        #endif
+        < script async src = "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3010246710169742"
+            crossorigin = "anonymous" ></ script >
     }
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/Involver/Pages/Shared/_Layout.cshtml
+++ b/Involver/Pages/Shared/_Layout.cshtml
@@ -6,14 +6,18 @@
         @if (!userManager.GetUserAsync(User).Result.Prime)
         {
             //Google AdSense
-            <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3010246710169742"
-            crossorigin="anonymous"></script>
+            #if !DEBUG
+                < script async src = "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3010246710169742"
+                    crossorigin = "anonymous" ></ script >
+            #endif
         }
     }
     else
     {
-        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3010246710169742"
-            crossorigin="anonymous"></script>
+        #if !DEBUG
+            < script async src = "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3010246710169742"
+                crossorigin = "anonymous" ></ script >
+        #endif
     }
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/InvolverRoutineWork/InvolverRoutineWork.csproj
+++ b/InvolverRoutineWork/InvolverRoutineWork.csproj
@@ -7,14 +7,21 @@
     <ImplicitUsings>enabled</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Core" Version="1.47.1" />
+    <PackageReference Include="Azure.Identity" Version="1.14.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.18">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/InvolverTest/Extensions/StringExtensionsTests.cs
+++ b/InvolverTest/Extensions/StringExtensionsTests.cs
@@ -27,7 +27,7 @@ namespace InvolverTest.Extensions
                 s);
 
             // Assert
-            Assert.AreEqual("aaa0890957be5148be6b9066461cf9b4", result);
+            Assert.That("aaa0890957be5148be6b9066461cf9b4" == result);
         }
 
         [Test]
@@ -41,7 +41,7 @@ namespace InvolverTest.Extensions
                 s);
 
             // Assert
-            Assert.AreEqual("312112d06c5f78cb50ca55a1bbe5bb60", result);
+            Assert.That("312112d06c5f78cb50ca55a1bbe5bb60" == result);
         }
     }
 }

--- a/InvolverTest/Helpers/DiceHelperTests.cs
+++ b/InvolverTest/Helpers/DiceHelperTests.cs
@@ -27,8 +27,8 @@ namespace InvolverTest.Helpers
                 ref strToDice);
 
             // Assert
-            Assert.IsTrue(result);
-            Assert.AreEqual("5D10: ", strToDice[..6]);
+            Assert.That(result);
+            Assert.That("5D10: " == strToDice[..6]);
         }
 
         [Test]
@@ -42,8 +42,8 @@ namespace InvolverTest.Helpers
                 ref strToDice);
 
             // Assert
-            Assert.IsTrue(result);
-            Assert.AreEqual("<p>5D10: ", strToDice[..9]);
+            Assert.That(result);
+            Assert.That("<p>5D10: " == strToDice[..9]);
         }
 
         [Test]
@@ -79,9 +79,9 @@ namespace InvolverTest.Helpers
             }
 
             // Assert
-            Assert.IsTrue(count1 > 0);
-            Assert.IsTrue(count2 > 0);
-            Assert.IsTrue(count3 > 0);
+            Assert.That(count1 > 0);
+            Assert.That(count2 > 0);
+            Assert.That(count3 > 0);
         }
     }
 }

--- a/InvolverTest/Helpers/PageSizeHelperTests.cs
+++ b/InvolverTest/Helpers/PageSizeHelperTests.cs
@@ -31,8 +31,8 @@ namespace InvolverTest.Helpers
                 ref endPage);
 
             // Assert
-            Assert.AreEqual(1, startPage);
-            Assert.AreEqual(1, endPage);
+            Assert.That(1 == startPage);
+            Assert.That(1 == endPage);
         }
 
         [Test]
@@ -52,8 +52,8 @@ namespace InvolverTest.Helpers
                 ref endPage);
 
             // Assert
-            Assert.AreEqual(1, startPage);
-            Assert.AreEqual(3, endPage);
+            Assert.That(1 == startPage);
+            Assert.That(3 == endPage);
         }
 
         [Test]
@@ -73,8 +73,8 @@ namespace InvolverTest.Helpers
                 ref endPage);
 
             // Assert
-            Assert.AreEqual(1, startPage);
-            Assert.AreEqual(5, endPage);
+            Assert.That(1 == startPage);
+            Assert.That(5 == endPage);
         }
 
         [Test]
@@ -94,8 +94,8 @@ namespace InvolverTest.Helpers
                 ref endPage);
 
             // Assert
-            Assert.AreEqual(1, startPage);
-            Assert.AreEqual(5, endPage);
+            Assert.That(1 == startPage);
+            Assert.That(5 == endPage);
         }
 
         [Test]
@@ -115,8 +115,8 @@ namespace InvolverTest.Helpers
                 ref endPage);
 
             // Assert
-            Assert.AreEqual(1, startPage);
-            Assert.AreEqual(3, endPage);
+            Assert.That(1 == startPage);
+            Assert.That(3 == endPage);
         }
 
         [Test]
@@ -136,8 +136,8 @@ namespace InvolverTest.Helpers
                 ref endPage);
 
             // Assert
-            Assert.AreEqual(1, startPage);
-            Assert.AreEqual(5, endPage);
+            Assert.That(1 == startPage);
+            Assert.That(5 == endPage);
         }
 
         [Test]
@@ -157,8 +157,8 @@ namespace InvolverTest.Helpers
                 ref endPage);
 
             // Assert
-            Assert.AreEqual(1, startPage);
-            Assert.AreEqual(5, endPage);
+            Assert.That(1 == startPage);
+            Assert.That(5 == endPage);
         }
 
         [Test]
@@ -178,8 +178,8 @@ namespace InvolverTest.Helpers
                 ref endPage);
 
             // Assert
-            Assert.AreEqual(3, startPage);
-            Assert.AreEqual(5, endPage);
+            Assert.That(3 == startPage);
+            Assert.That(5 == endPage);
         }
 
         [Test]
@@ -199,8 +199,8 @@ namespace InvolverTest.Helpers
                 ref endPage);
 
             // Assert
-            Assert.AreEqual(3, startPage);
-            Assert.AreEqual(7, endPage);
+            Assert.That(3 == startPage);
+            Assert.That(7 == endPage);
         }
 
         [Test]
@@ -220,8 +220,8 @@ namespace InvolverTest.Helpers
                 ref endPage);
 
             // Assert
-            Assert.AreEqual(5, startPage);
-            Assert.AreEqual(7, endPage);
+            Assert.That(5 == startPage);
+            Assert.That(7 == endPage);
         }
 
         [Test]
@@ -241,8 +241,8 @@ namespace InvolverTest.Helpers
                 ref endPage);
 
             // Assert
-            Assert.AreEqual(1, startPage);
-            Assert.AreEqual(4, endPage);
+            Assert.That(1 == startPage);
+            Assert.That(4 == endPage);
         }
     }
 }

--- a/InvolverTest/Helpers/TimePeriodHelperTests.cs
+++ b/InvolverTest/Helpers/TimePeriodHelperTests.cs
@@ -26,7 +26,7 @@ namespace InvolverTest.Helpers
                 time);
 
             // Assert
-            Assert.AreEqual("1個月前", result);
+            Assert.That("1個月前" == result);
         }
 
         [Test]
@@ -40,7 +40,7 @@ namespace InvolverTest.Helpers
                 time);
 
             // Assert
-            Assert.AreEqual("1年前", result);
+            Assert.That("1年前" == result);
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace InvolverTest.Helpers
                 time);
 
             // Assert
-            Assert.AreEqual("1年前", result);
+            Assert.That("1年前" == result);
         }
 
         [Test]
@@ -68,7 +68,7 @@ namespace InvolverTest.Helpers
                 time);
 
             // Assert
-            Assert.AreEqual("3年前", result);
+            Assert.That("3年前" == result);
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace InvolverTest.Helpers
                 time);
 
             // Assert
-            Assert.AreEqual("1分鐘前", result);
+            Assert.That("1分鐘前" == result);
         }
 
         [Test]
@@ -96,7 +96,7 @@ namespace InvolverTest.Helpers
                 time);
 
             // Assert
-            Assert.AreEqual("1小時前", result);
+            Assert.That("1小時前" == result);
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace InvolverTest.Helpers
                 time);
 
             // Assert
-            Assert.AreEqual("1小時前", result);
+            Assert.That("1小時前" == result);
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace InvolverTest.Helpers
                 time);
 
             // Assert
-            Assert.AreEqual("1天前", result);
+            Assert.That("1天前" == result);
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace InvolverTest.Helpers
                 time);
 
             // Assert
-            Assert.AreEqual("1天前", result);
+            Assert.That("1天前" == result);
         }
 
         [Test]
@@ -152,7 +152,7 @@ namespace InvolverTest.Helpers
                 time);
 
             // Assert
-            Assert.AreEqual("1個月前", result);
+            Assert.That("1個月前" == result);
         }
 
 

--- a/InvolverTest/InvolverTest.csproj
+++ b/InvolverTest/InvolverTest.csproj
@@ -5,11 +5,36 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="NSubstitute" Version="4.3.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="Azure.Core" Version="1.47.1" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
+    <PackageReference Include="Azure.Identity" Version="1.14.2" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
+    <PackageReference Include="HtmlSanitizer" Version="9.0.886" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.18">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="SendGrid" Version="9.29.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Involver\Involver.csproj" />

--- a/InvolverTest/InvolverTest.csproj
+++ b/InvolverTest/InvolverTest.csproj
@@ -1,42 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.47.1" />
-    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
-    <PackageReference Include="Azure.Identity" Version="1.14.2" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
-    <PackageReference Include="HtmlSanitizer" Version="9.0.886" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.18" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.18" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.18" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.18" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.18" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.18" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.18" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.18" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.18">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="SendGrid" Version="9.29.3" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Involver\Involver.csproj" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+		<PackageReference Include="NSubstitute" Version="5.3.0" />
+		<PackageReference Include="NUnit" Version="4.3.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Involver\Involver.csproj" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
#### PR Classification
更新 NuGet 套件版本並改善測試斷言風格。

#### PR Summary
本次拉取請求更新了多個 NuGet 套件的版本，並將測試中的斷言風格從 `Assert.AreEqual` 改為 `Assert.That`，以提升測試的現代化和一致性。
- `Involver.csproj`: 更新 Azure 相關套件、HtmlAgilityPack、HtmlSanitizer 和 Microsoft.ApplicationInsights.AspNetCore 的版本。
- `InvolverRoutineWork.csproj`: 添加 Azure 相關套件並更新 `Microsoft.EntityFrameworkCore.SqlServer` 和 `Microsoft.EntityFrameworkCore.Tools` 的版本。
- `StringExtensionsTests.cs` 和 `DiceHelperTests.cs`: 將 `Assert.AreEqual` 替換為 `Assert.That`。
- `PageSizeHelperTests.cs` 和 `TimePeriodHelperTests.cs`: 同樣將 `Assert.AreEqual` 替換為 `Assert.That`。
- `InvolverTest.csproj`: 更新測試相關的 NuGet 套件版本，包括 `Microsoft.NET.Test.Sdk` 和 `NUnit`。
