### PR TITLE
更新監控方案，移除 Application Insights

### DIFF
--- a/Involver/Involver.csproj
+++ b/Involver/Involver.csproj
@@ -116,10 +116,10 @@
     <PackageReference Include="Azure.Core" Version="1.47.1" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
     <PackageReference Include="Azure.Identity" Version="1.14.2" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
     <PackageReference Include="HtmlSanitizer" Version="9.0.886" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageReference Include="SendGrid" Version="9.29.3" />

--- a/Involver/Program.cs
+++ b/Involver/Program.cs
@@ -1,3 +1,5 @@
+using Azure.Identity;
+using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Involver.Data;
 using Involver.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -6,9 +8,12 @@ using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.EntityFrameworkCore;
 using WebPWrecover.Services;
-using Azure.Identity;
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Call AddOpenTelemetry() to add OpenTelemetry to your ServiceCollection.
+// Call UseAzureMonitor() to fully configure OpenTelemetry.
+builder.Services.AddOpenTelemetry().UseAzureMonitor();
 
 if (builder.Environment.IsProduction())
 {
@@ -110,13 +115,6 @@ services.AddAuthentication()
         facebookOptions.AppId = builder.Configuration["Authentication:Facebook:AppId"];
         facebookOptions.AppSecret = builder.Configuration["Authentication:Facebook:AppSecret"];
     });
-
-//TODO: Remember it's probably need to use ApplicationInsights.config file instead.
-builder.Logging.AddApplicationInsights(
-        configureTelemetryConfiguration: (config) =>
-            config.ConnectionString = builder.Configuration.GetConnectionString("APPLICATIONINSIGHTS_CONNECTION_STRING"),
-            configureApplicationInsightsLoggerOptions: (options) => { }
-    );
 
 services.AddDistributedMemoryCache();
 


### PR DESCRIPTION
在 `Involver.csproj` 中，新增 `Azure.Monitor.OpenTelemetry.AspNetCore` 套件，版本為 `1.2.0`，並移除 `Microsoft.ApplicationInsights.AspNetCore` 套件。 在 `Program.cs` 中，調整引用，新增 OpenTelemetry 配置，並在生產環境中配置 Azure Key Vault。