### PR TITLE
更新 .gitignore 檔案以忽略特定檔案

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,6 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+
+# MCP files
+*mcp.json


### PR DESCRIPTION
在 .gitignore 中新增了對 MCP 檔案和 JSON 檔案的忽略規則，避免將 `*mcp.json` 檔案納入版本控制。