### PR TITLE
UI 修改

### DIFF
--- a/Involver/Pages/Articles/Details.cshtml
+++ b/Involver/Pages/Articles/Details.cshtml
@@ -108,7 +108,7 @@
                         title="複製連結成功">
                     <i class="fas fa-copy"></i> 分享
                 </button>
-                <div class="fb-share-button" data-href="@shareUrl" data-layout="button_count"></div>
+                <div class="fb-share-button d-none d-md-inline-block" data-href="@shareUrl" data-layout="button_count"></div>
             </div>
         </div>
     </div>

--- a/Involver/Pages/Episodes/Details.cshtml
+++ b/Involver/Pages/Episodes/Details.cshtml
@@ -97,7 +97,7 @@
                         title="複製連結成功">
                     <i class="fas fa-copy"></i> 分享
                 </button>
-                <div class="fb-share-button" data-href="@shareUrl" data-layout="button_count"></div>
+                <div class="fb-share-button d-none d-md-inline-block" data-href="@shareUrl" data-layout="button_count"></div>
             </div>
         </div>
     </div>

--- a/Involver/Pages/Index.cshtml
+++ b/Involver/Pages/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+@page
 @model Involver.Pages.IndexModel
 @{
     ViewData["Title"] = "屬於每個人的創作";
@@ -104,7 +104,7 @@ else
 
 <p></p>
 <!-- Your share button code -->
-@* <div class="fb-share-button"
+@* <div class="fb-share-button d-none d-md-inline-block"
      data-href="https://involver.tw"
      data-layout="button_count">
 </div> *@

--- a/Involver/Views/Shared/Components/CommentSection/Default.cshtml
+++ b/Involver/Views/Shared/Components/CommentSection/Default.cshtml
@@ -101,7 +101,7 @@
                             <i :class="comment.isAgreedByCurrentUser ? 'fas fa-thumbs-up' : 'far fa-thumbs-up'"></i> <span>{{ comment.agreesCount }}</span>
                         </button>
                         <!-- Dropdown Menu -->
-                        <div class="dropdown d-inline-flex ml-auto">
+                        <div v-if="comment.canEdit || comment.canBlock" class="dropdown d-inline-flex ml-auto">
                             <button type="button" class="btn btn-link text-secondary" data-toggle="dropdown"><i class="fas fa-ellipsis-h"></i></button>
                             <div class="dropdown-menu dropdown-menu-right">
                                 <button v-if="comment.canEdit && comment.dices.length === 0" @@click="toggleCommentEdit(comment)" class="dropdown-item">


### PR DESCRIPTION
## UI 修改
* 在窄螢幕上隱藏FB分享按鈕，以解決排版被壓縮的問題。
* 若用戶沒有權限，隱藏留言操作 Menu。